### PR TITLE
Adds maximum width to legends

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -176,6 +176,11 @@
               showInLegend: data.showDataLegend
             }
           },
+          legend: {
+            itemStyle: {
+              width: '100%'
+            }
+          },
           series: [{
             name: data.name,
             colorByPoint: true,


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2059

Allows line wrapping with legends

<img width="641" alt="image 2018-01-24 at 4 45 59 pm" src="https://user-images.githubusercontent.com/290733/35344924-29e3b04a-0126-11e8-886a-5a4a0945a353.png">