### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -59,6 +59,10 @@
                     value = $.trim(value);
                   }
 
+                  if (!value) {
+                    return;
+                  }
+
                   if (!Array.isArray(value)) {
                     value = [value];
                   }


### PR DESCRIPTION
@tonytlwu @squallstar

## Issue
Fliplet/fliplet-studio#4879

## Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data.

## Screenshots/screencasts
Before:
<img width="343" alt="Pie demo 1" src="https://user-images.githubusercontent.com/52824207/64525559-cc769280-d309-11e9-8943-b4a6e69cac68.png">

After:
<img width="343" alt="Pie demo 2" src="https://user-images.githubusercontent.com/52824207/64525557-cc769280-d309-11e9-971d-d7fc3139f1ae.png">

## Backward compatibility
This change is fully backward compatible.