### PR TITLE
Allow users to give charts personalized colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history
+node_modules

--- a/js/build.js
+++ b/js/build.js
@@ -137,15 +137,11 @@
       /**
        * A function that searches for a custom style of the widget
        *
-       * @returns {object/null} returns a color object or false if there is no custom color used for this widget
+       * @returns {object/null} returns a color object or null if there is no custom color used for this widget
        */
       function getCustomColors() {
-        var widgetData = window.__widgetData;
-        var widgetDataKeys = Object.keys(widgetData);
-        var themeKey = widgetDataKeys.find(function(key) {
-          return widgetData[key] && widgetData[key].data && widgetData[key].data.values;
-        });
-        var widgetInstances = themeKey ? widgetData[themeKey].data.widgetInstances : [];
+        var widgetData = Fliplet.Themes.Current.getInstance();
+        var widgetInstances = widgetData ? widgetData.data.widgetInstances : [];
         var chartInstance = widgetInstances.find(function(instance) {
           return instance.uuid === chartUuid;
         });
@@ -213,7 +209,7 @@
       });
 
       function drawChart() {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function(resolve, reject) {
           var customColors = getCustomColors();
 
           colors.forEach(function eachColor(color, index) {

--- a/js/build.js
+++ b/js/build.js
@@ -135,11 +135,11 @@
       }
 
       /**
-       * A function that searches for a personal style of the widget
+       * A function that searches for a custom style of the widget
        *
-       * @returns {object/null} returns a color object or false if there is no personal color used for this widget
+       * @returns {object/null} returns a color object or false if there is no custom color used for this widget
        */
-      function getPersonalColors() {
+      function getCustomColors() {
         var widgetData = window.__widgetData;
         var widgetDataKeys = Object.keys(widgetData);
         var themeKey = widgetDataKeys.find(function(key) {
@@ -213,8 +213,8 @@
       });
 
       function drawChart() {
-        return new Promise(function(resolve, reject) {
-          var personalColors = getPersonalColors();
+        return new Promise(function (resolve, reject) {
+          var customColors = getCustomColors();
 
           colors.forEach(function eachColor(color, index) {
             if (!Fliplet.Themes) {
@@ -222,8 +222,8 @@
             }
 
             var colorKey = 'chartColor' + (index + 1);
-            var newColor = personalColors
-              ? personalColors[colorKey]
+            var newColor = customColors
+              ? customColors[colorKey]
               : Fliplet.Themes.Current.get(colorKey);
             
             if (newColor) {

--- a/js/build.js
+++ b/js/build.js
@@ -134,21 +134,6 @@
         })
       }
 
-      /**
-       * A function that searches for a custom style of the widget
-       *
-       * @returns {object/null} returns a color object or null if there is no custom color used for this widget
-       */
-      function getCustomColors() {
-        var widgetData = Fliplet.Themes.Current.getInstance();
-        var widgetInstances = widgetData ? widgetData.data.widgetInstances : [];
-        var chartInstance = widgetInstances.find(function(instance) {
-          return instance.uuid === chartUuid;
-        });
-
-        return chartInstance ? chartInstance.values : null;
-      }
-
       function refreshChartInfo() {
         // Update total count
         $container.find('.total').html(data.totalEntries);
@@ -210,7 +195,7 @@
 
       function drawChart() {
         return new Promise(function(resolve, reject) {
-          var customColors = getCustomColors();
+          var customColors = Fliplet.Themes.Current.getSettingsForWidgetInstance(chartUuid);
 
           colors.forEach(function eachColor(color, index) {
             if (!Fliplet.Themes) {


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5477#issuecomment-617719084

## Description
Added function that searches for personalized colors.

## Screenshots/screencasts
https://share.getcloudapp.com/yAu221Y7

## Backward compatibility

This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 

## Notes
We implement personal colors over general colors.