### PR TITLE
[Fix] Custom colors will apply for the Chart: Pie as expected

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -204,7 +204,7 @@
 
             var colorKey = 'chartColor' + (index + 1);
             var newColor = customColors
-              ? customColors[colorKey]
+              ? customColors.values[colorKey]
               : Fliplet.Themes.Current.get(colorKey);
             
             if (newColor) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5477

## Description
Custom colors will apply for the Chart: Pie as expected

## Screenshots/screencasts
https://share.getcloudapp.com/DOuQEEeq

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko