### PR TITLE
ID-458 [Feat] Adds chart name and support for refreshing via JS API

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -66,6 +66,13 @@
         </div>
       </div>
     </div>
-
+    <div class="form-group">
+      <div class="col-sm-4 control-label">
+        <label for="chart_name">Chart name (for JS API)</label> <a href="https://developers.fliplet.com/API/components/charts.html">Learn more</a>
+      </div>
+      <div class="col-sm-8">
+        <input type="text" class="form-control" id="chart_name" name="chart_name" placeholder="(Optional)" value="">
+      </div>
+    </div>
   </div>
 </div>

--- a/js/build.js
+++ b/js/build.js
@@ -2,12 +2,20 @@
   window.ui = window.ui || {}
   ui.flipletCharts = ui.flipletCharts || {};
 
+  Fliplet.Chart = Fliplet.Widget.Namespace('chart');
+
   function init() {
     Fliplet.Widget.instance('chart-pie', function (data) {
       var chartId = data.id;
       var $container = $(this);
       var refreshTimeout = 5000;
+      var refreshTimer;
       var updateDateFormat = 'hh:mm:ss a';
+
+      var chartReady;
+      var chartPromise = new Promise(function(resolve) {
+        chartReady = resolve;
+      });
 
       function resetData() {
         data.entries = [];
@@ -149,25 +157,33 @@
         return Promise.resolve(chart);
       }
 
-      function getLatestData() {
-        return new Promise(function (resolve, reject) {
-          setTimeout(function () {
-            refreshData().then(function () {
-              if (data.autoRefresh) {
-                getLatestData();
-              }
+      function refresh() {
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+          refreshTimer = null;
+        }
 
-              refreshChart();
-              resolve();
-            }).catch(function (err) {
-              if (data.autoRefresh) {
-                getLatestData();
-              }
+        return refreshData().then(function () {
+          if (data.autoRefresh) {
+            setRefreshTimer();
+          }
 
-              reject(err);
-            });
-          }, refreshTimeout);
+          return refreshChart();
+        }).catch(function (err) {
+          if (data.autoRefresh) {
+            setRefreshTimer();
+          }
+
+          return Promise.reject(err);
         });
+      }
+
+      function setRefreshTimer() {
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+        }
+
+        refreshTimer = setTimeout(refresh, refreshTimeout);
       }
 
       function drawChart() {
@@ -196,7 +212,7 @@
                 load: function(){
                   refreshChartInfo();
                   if (data.autoRefresh) {
-                    getLatestData();
+                    setRefreshTimer();
                   }
                 },
                 render: function () {
@@ -310,7 +326,15 @@
 
       refreshData().then(drawChart).catch(function(error){
         console.error(error);
-        getLatestData();
+        setRefreshTimer();
+      });
+
+      Fliplet.Chart.add(chartPromise);
+
+      chartReady({
+        name: data.chartName,
+        type: 'pie',
+        refresh: refresh
       });
     });
   }

--- a/js/interface.js
+++ b/js/interface.js
@@ -103,6 +103,7 @@ function attachObservers() {
       chartHeightMd: $('#chart_height_md').val(),
       showDataLegend: $('#show_data_legend').is(':checked'),
       showDataValues: $('#show_data_values').is(':checked'),
+      chartName: $('#chart_name').val(),
       showTotalEntries: $('#show_total_entries').is(':checked'),
       autoRefresh: $('#auto_refresh').is(':checked')
     }).then(function () {
@@ -114,7 +115,7 @@ function attachObservers() {
   // Fired from Fliplet Studio when the external save button is clicked
   Fliplet.Widget.onSaveRequest(function () {
     dsQueryProvider.forwardSaveRequest();
-  });  
+  });
 }
 
 attachObservers();
@@ -125,6 +126,7 @@ if (data) {
   $('#chart_height_md').val(data.chartHeightMd);
   $('#show_data_legend').prop('checked', data.showDataLegend);
   $('#show_data_values').prop('checked', data.showDataValues);
+  $('#chart_name').val(data.chartName);
   $('#show_total_entries').prop('checked', data.showTotalEntries);
   $('#auto_refresh').prop('checked', data.autoRefresh);
 }


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-458

Requires https://github.com/Fliplet/fliplet-api/pull/4384

Adds support for:

```js
Fliplet.Chart.get('My chart').then(function(chart) {
  // Refresh chart
  chart.refresh();
});
```

![image](https://user-images.githubusercontent.com/290733/99992204-efc21c00-2dad-11eb-9260-fa279ca5dde9.png)
