### PR TITLE
ID-3447 [FIX] Ensure theme appearance color settings for individual chart should not affect other present charts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "fliplet",
   "rules": {
-    "Highcharts": "readonly",
-    "ui": "readonly"
+    "Highcharts": 0,
+    "ui": 0
   }
 }

--- a/js/build.js
+++ b/js/build.js
@@ -14,38 +14,41 @@ Fliplet.Widget.instance('chart-pie-1-1-0', function(data) {
     var themeValue = themeInstance.data.values || {};
 
     Fliplet.Themes.get().then(function(themes) {
-      if ((themes || []).length) {
-        _.some(themes, function(theme) {
-          _.some(theme.instances, function(instance) {
-            if (instance.settings.values) {
-              themeValue = Object.assign({}, theme.settings.values);
+      if (!(themes || []).length) {
+        return;
+      }
+      _.some(themes, function(theme) {
+        _.some(theme.instances, function(instance) {
+          if (!instance.settings.values) {
+            return;
+          }
+          
+          themeValue = Object.assign({}, theme.settings.values);
 
-              var widgetValue = getColors(themeInstance.data.widgetInstances);
+          var widgetValue = getColors(themeInstance.data.widgetInstances);
 
-              if ((themeInstance.data.widgetInstances || []).length) {
-                var instanceFound = _.some(themeInstance.data.widgetInstances, function(widgetProp) {
-                  if (chartId === widgetProp.id) {
-                    themeValues = Object.assign(themeValue, widgetValue);
-                    Object.assign(widgetProp.values, themeValues);
-
-                    return true;
-                  }
-                });
-
-                if (!instanceFound) {
-                  themeValues = Object.assign({}, themeValue);
-                }
-              } else {
+          if ((themeInstance.data.widgetInstances || []).length) {
+            var instanceFound = _.some(themeInstance.data.widgetInstances, function(widgetProp) {
+              if (chartId === widgetProp.id) {
                 themeValues = Object.assign(themeValue, widgetValue);
-              }
+                Object.assign(widgetProp.values, themeValues);
 
-              return true;
+                return true;
+              }
+            });
+
+            if (!instanceFound) {
+              themeValues = Object.assign({}, themeValue);
             }
-          });
+          } else {
+            themeValues = Object.assign(themeValue, widgetValue);
+          }
+
           return true;
         });
-      }
-    })
+        return true;
+      });
+    });
   }
 
   var inheritColor1 = true;

--- a/js/build.js
+++ b/js/build.js
@@ -17,12 +17,13 @@ Fliplet.Widget.instance('chart-pie-1-1-0', function(data) {
       if (!(themes || []).length) {
         return;
       }
+
       _.some(themes, function(theme) {
         _.some(theme.instances, function(instance) {
           if (!instance.settings.values) {
             return;
           }
-          
+
           themeValue = Object.assign({}, theme.settings.values);
 
           var widgetValue = getColors(themeInstance.data.widgetInstances);
@@ -46,6 +47,7 @@ Fliplet.Widget.instance('chart-pie-1-1-0', function(data) {
 
           return true;
         });
+
         return true;
       });
     });
@@ -282,11 +284,11 @@ Fliplet.Widget.instance('chart-pie-1-1-0', function(data) {
         return Fliplet.Themes.Current.get(colorKey) || Fliplet.Themes.Current.get(color);
       } else if (newColor) {
         return newColor;
-      } else {
-        var colors = defaultColors.slice();
-
-        return colors[index];
       }
+
+      var colors = defaultColors.slice();
+
+      return colors[index];
     }
 
     Fliplet.Studio.onEvent(function(event) {
@@ -430,8 +432,8 @@ Fliplet.Widget.instance('chart-pie-1-1-0', function(data) {
       colors.forEach(function(defaultColor, index) {
         var colorKey = 'chartColor' + (index + 1);
         var newColor = customColors
-            ? customColors.values[colorKey]
-            : Fliplet.Themes.Current.get(colorKey);
+          ? customColors.values[colorKey]
+          : Fliplet.Themes.Current.get(colorKey);
 
         if (themeValues && !customColors) {
           newColor = themeValues[colorKey];


### PR DESCRIPTION
**Product areas affected**

Studio -> Pie Chart -> Theme appearance settings

**What does this PR do?**

Implemented code, so theme appearance color settings for individual chart should not affect other present charts

**JIRA ticket**

[ID-3447](https://weboo.atlassian.net/browse/ID-3447)

**Result**

https://github.com/Fliplet/fliplet-widget-chart-pie/assets/108272606/5a259123-da69-49b5-b85e-074fde01f11f

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None


[ID-3447]: https://weboo.atlassian.net/browse/ID-3447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ